### PR TITLE
Fixed webpack `webpack define cannot be used indirect` caused by cert…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "request": "^2.55.0",
+    "request": "github:request/request#2351a8c",
     "q": "2.0.3",
     "URIjs": "^1.15.0"
   },


### PR DESCRIPTION
…ain request versions
